### PR TITLE
Setup docker compose for keycloak

### DIFF
--- a/tools/docker-compose.yaml
+++ b/tools/docker-compose.yaml
@@ -1,0 +1,60 @@
+services:
+  postgres:
+    image: postgres:17.4
+    container_name: postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: admin
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
+    networks:
+      - app-network
+
+  keycloak:
+    image: keycloak/keycloak:26.1.4
+    container_name: keycloak
+    restart: unless-stopped
+    command: start-dev
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak_db
+      KC_DB_USERNAME: keycloak_user
+      KC_DB_PASSWORD: keycloakpassword
+      KC_HOSTNAME: localhost
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HTTP_RELATIVE_PATH: /auth
+    ports:
+      - "8081:8080"
+    depends_on:
+      - postgres
+    networks:
+      - app-network
+    volumes:
+      - keycloak-data:/opt/keycloak/data
+
+  nginx:
+    image: nginx:1.27.4-perl
+    container_name: nginx
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - keycloak
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  postgres-data:
+    driver: local
+  keycloak-data:
+    driver: local

--- a/tools/init-db.sh
+++ b/tools/init-db.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE DATABASE keycloak_db;
+    CREATE USER keycloak_user WITH ENCRYPTED PASSWORD 'keycloakpassword';
+    GRANT ALL PRIVILEGES ON DATABASE keycloak_db TO keycloak_user;
+
+    CREATE DATABASE app_db;
+    CREATE USER app_user WITH ENCRYPTED PASSWORD 'apppassword';
+    GRANT ALL PRIVILEGES ON DATABASE app_db TO app_user;
+
+    \c keycloak_db
+    ALTER SCHEMA public OWNER TO keycloak_user;
+    GRANT ALL ON SCHEMA public TO keycloak_user;
+
+    \c app_db
+    ALTER SCHEMA public OWNER TO app_user;
+    GRANT ALL ON SCHEMA public TO app_user;
+EOSQL

--- a/tools/nginx.conf
+++ b/tools/nginx.conf
@@ -1,0 +1,26 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+    keepalive_timeout 30;
+
+
+    server {
+        listen 8080;
+
+        location /auth/ {
+            proxy_pass http://keycloak:8080;
+        }
+
+        location / {
+            proxy_pass http://host.docker.internal:8082;
+        }
+    }
+}


### PR DESCRIPTION
First part of keycloak setup. docker compose file and reverse proxy. Keycloak is available for development on localhost:8080/auth.